### PR TITLE
Fixed release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        modelgroup: ["Basenji,CleTimer,FactorNet", "DeepBind", "lsgkm-SVM", "rbp_eclip"]
+        modelgroup: ["Basenji", "CleTimer", "FactorNet", "DeepBind", "lsgkm-SVM", "rbp_eclip"]
     runs-on: ubuntu-latest
     env:
       SINGULARITY_PULL_FOLDER: "/home/runner/singularity/"
@@ -193,33 +193,37 @@ jobs:
         sudo apt-get update && sudo apt-get install -y libhdf5-serial-dev pkg-config
         python -m pip install --upgrade pip
         pip install .
-    - name: Build sharedpy3keras2tf1, sharedpy3keras2tf1-slim and kipoi-base-env
+    - name: Build and push sharedpy3keras2tf1 and kipoi-base-env
       shell: bash -l {0}
       run: |
         docker build -f dockerfiles/Dockerfile.kipoi-base-env -t kipoi/kipoi-docker:kipoi-base-env . 
         docker build -f dockerfiles/Dockerfile.sharedpy3keras2tf1 -t kipoi/kipoi-docker:sharedpy3keras2tf1 . 
-        docker build -f dockerfiles/Dockerfile.sharedpy3keras2tf1-slim -t kipoi/kipoi-docker:sharedpy3keras2tf1-slim . 
-    - name: Push sharedpy3keras2tf1, sharedpy3keras2tf1-slim and kipoi-base-env
+        docker login --username ${{ secrets.DOCKERUSERNAME }} --password ${{ secrets.DOCKERPASSWORD }}
+        docker push kipoi/kipoi-docker:kipoi-base-env
+        docker push kipoi/kipoi-docker:sharedpy3keras2tf1
+        docker system prune -a -f
+    - name: Build and push sharedpy3keras2tf1-slim
       shell: bash -l {0}
       if: ${{ success() }}
       run: |
         docker login --username ${{ secrets.DOCKERUSERNAME }} --password ${{ secrets.DOCKERPASSWORD }}
-        docker push kipoi/kipoi-docker:kipoi-base-env
-        docker push kipoi/kipoi-docker:sharedpy3keras2tf1
+        docker build -f dockerfiles/Dockerfile.sharedpy3keras2tf1-slim -t kipoi/kipoi-docker:sharedpy3keras2tf1-slim . 
         docker push kipoi/kipoi-docker:sharedpy3keras2tf1-slim
         docker system prune -a -f
-    - name: Build sharedpy3keras2tf2, sharedpy3keras2tf2-slim and kipoi-base-env
+    - name: Build and push sharedpy3keras2tf2
       shell: bash -l {0}
       run: |
         docker build -f dockerfiles/Dockerfile.kipoi-base-env -t kipoi/kipoi-docker:kipoi-base-env . 
         docker build -f dockerfiles/Dockerfile.sharedpy3keras2tf2 -t kipoi/kipoi-docker:sharedpy3keras2tf2 . 
-        docker build -f dockerfiles/Dockerfile.sharedpy3keras2tf2-slim -t kipoi/kipoi-docker:sharedpy3keras2tf2-slim . 
-    - name: Push sharedpy3keras2tf2 and sharedpy3keras2tf2-slim
+        docker login --username ${{ secrets.DOCKERUSERNAME }} --password ${{ secrets.DOCKERPASSWORD }}
+        docker push kipoi/kipoi-docker:sharedpy3keras2tf2
+        docker system prune -a -f
+    - name: Build and push sharedpy3keras2tf2-slim
       shell: bash -l {0}
       if: ${{ success() }}
       run: |
+        docker build -f dockerfiles/Dockerfile.sharedpy3keras2tf2-slim -t kipoi/kipoi-docker:sharedpy3keras2tf2-slim . 
         docker login --username ${{ secrets.DOCKERUSERNAME }} --password ${{ secrets.DOCKERPASSWORD }}
-        docker push kipoi/kipoi-docker:sharedpy3keras2tf2
         docker push kipoi/kipoi-docker:sharedpy3keras2tf2-slim
         docker system prune -a -f
   buildtestandpushsingularity:

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -213,7 +213,6 @@ jobs:
     - name: Build and push sharedpy3keras2tf2
       shell: bash -l {0}
       run: |
-        docker build -f dockerfiles/Dockerfile.kipoi-base-env -t kipoi/kipoi-docker:kipoi-base-env . 
         docker build -f dockerfiles/Dockerfile.sharedpy3keras2tf2 -t kipoi/kipoi-docker:sharedpy3keras2tf2 . 
         docker login --username ${{ secrets.DOCKERUSERNAME }} --password ${{ secrets.DOCKERPASSWORD }}
         docker push kipoi/kipoi-docker:sharedpy3keras2tf2

--- a/kipoi_containers/singularityhandler.py
+++ b/kipoi_containers/singularityhandler.py
@@ -25,9 +25,9 @@ class SingularityHandler:
     model_group: str
     docker_image_name: str
     model_group_to_singularity_dict: Dict
+    workflow_release_data: Dict
     singularity_image_folder: Union[str, Path] = None
     zenodo_client: zenodoclient.Client = zenodoclient.Client()
-    workflow_release_data: Dict = {}
 
     def __post_init__(self):
         """If a location has not been specified for saving the downloaded

--- a/kipoi_containers/singularityhandler.py
+++ b/kipoi_containers/singularityhandler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, Union, List, Type
 import os
 
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
 from kipoi_containers.singularityhelper import (
     build_singularity_image,
@@ -26,6 +27,7 @@ class SingularityHandler:
     model_group_to_singularity_dict: Dict
     singularity_image_folder: Union[str, Path] = None
     zenodo_client: zenodoclient.Client = zenodoclient.Client()
+    workflow_release_data: Dict = {}
 
     def __post_init__(self):
         """If a location has not been specified for saving the downloaded
@@ -45,6 +47,16 @@ class SingularityHandler:
             for k, v in updated_singularity_dict.items()
             if k in ["url", "name", "md5"]
         }
+
+    def update_release_workflow(self) -> None:
+        """Update .github/workflows/release-workflow.yml with the newly
+        added model group if it is not using one of the shared environments"""
+        if "shared" not in self.singularity_image_name:
+            self.workflow_release_data["jobs"]["buildtestandpushsingularity"][
+                "strategy"
+            ]["matrix"]["image"].append(
+                DoubleQuotedScalarString(self.docker_image_name.split(":")[1])
+            )
 
     def add(
         self,
@@ -101,6 +113,7 @@ class SingularityHandler:
                 example_model.split("/")[0]
             ]
         self.update_container_info(new_singularity_dict)
+        self.update_release_workflow()
 
     def update(self, models_to_test: List, push: bool = True) -> None:
         """Updates an existing singularity image. The steps are as follows -

--- a/kipoi_containers/update_all_singularity_images.py
+++ b/kipoi_containers/update_all_singularity_images.py
@@ -70,6 +70,7 @@ def run_update(docker_image: str) -> None:
         docker_image_name=docker_image,
         singularity_image_folder=singularity_pull_folder,
         model_group_to_singularity_dict=model_group_to_singularity_dict,
+        workflow_release_data={},
     )
     if "slim" in docker_image:
         models_to_test = one_model_per_modelgroup(

--- a/kipoi_containers/updateoradd.py
+++ b/kipoi_containers/updateoradd.py
@@ -160,6 +160,7 @@ class ModelSyncer:
                 model_group=model_group,
                 docker_image_name=f"{model_adder.image_name}-slim",
                 model_group_to_singularity_dict=self.model_group_to_singularity_dict,
+                workflow_release_data=self.workflow_release_data,
             )
             singularity_handler.add(
                 model_adder.list_of_models

--- a/kipoi_containers/updateoradd.py
+++ b/kipoi_containers/updateoradd.py
@@ -143,7 +143,7 @@ class ModelSyncer:
                 singularity_handler.update(models_to_test)
             else:
                 print(
-                    f"We will not be updating {name_of_docker_image} an {slim_docker_image}"
+                    f"We will not be updating {name_of_docker_image} and {slim_docker_image}"
                 )
         else:
             model_adder = DockerAdder(

--- a/kipoi_containers/updateoradd.py
+++ b/kipoi_containers/updateoradd.py
@@ -127,6 +127,7 @@ class ModelSyncer:
                 model_group=model_group,
                 docker_image_name=slim_docker_image,
                 model_group_to_singularity_dict=self.model_group_to_singularity_dict,
+                workflow_release_data=self.workflow_release_data,
             )
             if "shared" not in name_of_docker_image:
                 docker_updater = DockerUpdater(

--- a/test-singularity/test_singularity_handler.py
+++ b/test-singularity/test_singularity_handler.py
@@ -256,7 +256,13 @@ def test_singularityhandler_add(
         docker_image_name="kipoi/kipoi-docker:mpra-dragonn",
         singularity_image_folder=cwd,
         model_group_to_singularity_dict=model_group_to_singularity_dict,
-        workflow_release_data={},
+        workflow_release_data={
+            "jobs": {
+                "buildtestandpushsingularity": {
+                    "strategy": {"matrix": {"image": ["dummy"]}}
+                }
+            }
+        },
     )
     monkeypatch.setattr(
         "kipoi_containers.singularityhandler.cleanup", mock_cleanup
@@ -297,3 +303,6 @@ def test_singularityhandler_add(
         original_container_dict
         != singularity_handler.model_group_to_singularity_dict
     )
+    assert singularity_handler.workflow_release_data["jobs"][
+        "buildtestandpushsingularity"
+    ]["strategy"]["matrix"]["image"] == ["dummy", "mpra-dragonn"]

--- a/test-singularity/test_singularity_handler.py
+++ b/test-singularity/test_singularity_handler.py
@@ -32,6 +32,7 @@ def test_pull_folder(monkeypatch, model_group_to_singularity_dict):
         model_group="Basset",
         docker_image_name="kipoi://kipoi-docker:basset-slim",
         model_group_to_singularity_dict=model_group_to_singularity_dict,
+        workflow_release_data={},
     )
     assert Path(singularity_handler.singularity_image_folder) == Path(
         "/usr/src/imaginary-folder"
@@ -44,6 +45,7 @@ def test_singularityhandler_init(model_group_to_singularity_dict, cwd):
         docker_image_name="kipoi://kipoi-docker:basset-slim",
         model_group_to_singularity_dict=model_group_to_singularity_dict,
         singularity_image_folder=cwd,
+        workflow_release_data={},
     )
     assert singularity_handler.singularity_image_folder == cwd
     assert (
@@ -64,6 +66,7 @@ def test_singularityhandler_update_container_info(
         docker_image_name="kipoi://kipoi-docker:dummymodel-slim",
         model_group_to_singularity_dict=model_group_to_singularity_dict,
         singularity_image_folder=cwd,
+        workflow_release_data={},
     )
     singularity_json = MODEL_GROUP_TO_SINGULARITY_JSON
     github_obj = Github(os.environ["GITHUB_TOKEN"])
@@ -114,6 +117,7 @@ def test_singularityhandler_noupdate(
         docker_image_name="kipoi/kipoi-docker:deepmel-slim",
         singularity_image_folder=cwd,
         model_group_to_singularity_dict=model_group_to_singularity_dict,
+        workflow_release_data={},
     )
     monkeypatch.setattr(
         "kipoi_containers.singularityhandler.cleanup", mock_cleanup
@@ -176,6 +180,7 @@ def test_singularityhandler_update(
         docker_image_name="kipoi/kipoi-docker:mpra-dragonn-slim",
         singularity_image_folder=cwd,
         model_group_to_singularity_dict=model_group_to_singularity_dict,
+        workflow_release_data={},
     )
     monkeypatch.setattr(
         "kipoi_containers.singularityhandler.cleanup", mock_cleanup
@@ -251,6 +256,7 @@ def test_singularityhandler_add(
         docker_image_name="kipoi/kipoi-docker:mpra-dragonn",
         singularity_image_folder=cwd,
         model_group_to_singularity_dict=model_group_to_singularity_dict,
+        workflow_release_data={},
     )
     monkeypatch.setattr(
         "kipoi_containers.singularityhandler.cleanup", mock_cleanup

--- a/test-singularity/test_singularity_helper.py
+++ b/test-singularity/test_singularity_helper.py
@@ -43,9 +43,7 @@ def test_get_available_sc_depositions(zenodo_client):
         MODEL_GROUP_TO_SINGULARITY_JSON, kipoi_model_repo
     )
     singularity_handler = singularityhandler.SingularityHandler(
-        "Basset",
-        "Dummy",
-        original_container_dict,
+        "Basset", "Dummy", original_container_dict, {}
     )
     available_singularity_containers = [
         container["name"]


### PR DESCRIPTION
1. Release workflow now is correctly allocating and managing memory. There were a few out of memory warnings with building and testing kipoi/kipoi-docker:sharedpy3kerastf1  in the end, it finished successfully. 
2. A bug is fixed in addition of singularity container in buildtestsingularity job in release-workflow.