### PR TITLE
Addition of a random delay at post content

### DIFF
--- a/kipoi_containers/zenodoclient.py
+++ b/kipoi_containers/zenodoclient.py
@@ -1,10 +1,13 @@
 import json
 import os
 from pathlib import Path
+from typing import Dict, Tuple, Union
+from time import sleep
+
+from numpy.random import default_rng
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-from typing import Dict, Tuple, Union
 
 
 class Client:
@@ -54,8 +57,13 @@ class Client:
         return response.json()
 
     def post_content(self, url: str, **kwargs) -> Tuple[int, Dict]:
-        """Performs POST request to an url and returns the response status
+        """Sleeps for a random time between 5 and 20 seconds to ensure
+        zenodo backend is not receiving too many concurrent post requests.
+        After that, perform POST request to an url and returns the response status
         and body"""
+        rng = default_rng()
+        time_to_sleep = rng.uniform(5, 20)
+        sleep(time_to_sleep)
         response = requests.post(url, params=(self.params | kwargs), json={})
         response.raise_for_status()
         return response.status_code, response.json()


### PR DESCRIPTION
Adding another workaround to handle zenodo's intermittent failure with concurrent post requests. I have added a small random delay of 5-20 seconds before any post request is made. Hopefully this will prevent the failures.
